### PR TITLE
TypeError: Constructor Set requires 'new'

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "afterfn": "^2.0.0",
     "beforefn": "^2.2.0",
     "es6-map": "^0.1.0",
-    "es6-set": "^0.1.0",
+    "es6-set": "0.1.0",
     "guardfn": "^1.0.0",
     "inherits": "^2.0.1",
     "sliced": "0.0.5"


### PR DESCRIPTION
It appears the new version of es6-set doesn't return the polyfilled Set anymore if the current global has a native Set. I am running node v4.2.2.  Calling `new Graph` gives this error:

```
TypeError: Constructor Set requires 'new'
    at Graph.Set (native)
    at new Graph (node_modules/graphs/index.js:15:27)
```

Since built-ins cannot be extended, I am guessing this will break the inherits(Graph, Set) code as well, which is why the polyfilled version of Set worked. I worked around the issue by changing the package.json in graphs so it will user the older version of es6-set that always returns the polyfilled version.
